### PR TITLE
Fix/long form audio diarization

### DIFF
--- a/nemo-engine/Dockerfile
+++ b/nemo-engine/Dockerfile
@@ -21,8 +21,8 @@ RUN apt-get update && apt-get install build-essential -y && apt-get install -y -
 
 RUN pip install Cython
 RUN pip install megatron-core==0.3.0
-RUN pip install git+https://github.com/NVIDIA/NeMo.git@r1.22.0#egg=nemo_toolkit[asr]
-# RUN pip install git+https://github.com/NVIDIA/NeMo.git@main#egg=nemo_toolkit[all]
+# RUN pip install git+https://github.com/NVIDIA/NeMo.git@r1.22.0#egg=nemo_toolkit[asr]
+RUN pip install git+https://github.com/NVIDIA/NeMo.git@main#egg=nemo_toolkit[all]
 RUN pip install -r requirements.txt
 
 # Copy the current directory contents into the container at /app

--- a/nemo-engine/diar_infer_telephonic.yaml
+++ b/nemo-engine/diar_infer_telephonic.yaml
@@ -52,6 +52,8 @@ diarizer:
       max_rp_threshold: 0.25 # Determines the range of p-value search: 0 < p <= max_rp_threshold. 
       sparse_search_volume: 30 # The higher the number, the more values will be examined with more time. 
       maj_vote_spk_count: False  # If True, take a majority vote on multiple p-values to estimate the number of speakers.
+      chunk_cluster_count: 50 # Number of forced clusters (overclustering) per unit chunk in long-form audio clustering.
+      embeddings_per_chunk: 10000 # Number of embeddings in each chunk for long-form audio clustering. Adjust based on GPU memory capacity. (default: 10000, approximately 40 mins of audio) 
   
   msdd_model:
     model_path: diar_msdd_telephonic # .nemo local model path or pretrained model name for multiscale diarization decoder (MSDD)


### PR DESCRIPTION
Nvidia Nemo recently added long-form audio diarization in release 1.23. It works on large audio files of upto 8 hours. It was recently merged to main.

Short audio forms will work normally but when large audio files are detected Nemo switches to long form clustering as specified in diar_infer_telephonic.yaml.

The solution is based on this i[ssue](https://github.com/NVIDIA/NeMo/pull/7737l) 

